### PR TITLE
Change pod_hal_init() to return pointer to backbuffer

### DIFF
--- a/copepod_hal.c
+++ b/copepod_hal.c
@@ -58,7 +58,7 @@ static spi_device_handle_t spi;
 /*
  * Initializes the MIPI display and an optional framebuffer
  */
-void pod_hal_init(void)
+bitmap_t *pod_hal_init(void)
 {
     mipi_display_init(&spi);
 #ifdef CONFIG_POD_HAL_USE_DOUBLE_BUFFERING
@@ -69,6 +69,10 @@ void pod_hal_init(void)
         MALLOC_CAP_DMA | MALLOC_CAP_32BIT
     );
     bitmap_init(&fb, buffer);
+
+    return &fb;
+#else
+    return NULL;
 #endif
 }
 

--- a/copepod_hal.h
+++ b/copepod_hal.h
@@ -55,7 +55,7 @@ extern "C" {
 #define POD_HAS_HAL_INIT
 #define POD_HAS_HAL_FLUSH
 
-void pod_hal_init(void);
+bitmap_t *pod_hal_init(void);
 void pod_hal_flush();
 void pod_hal_put_pixel(int16_t x0, int16_t y0, uint16_t color);
 void pod_hal_blit(uint16_t x0, uint16_t y0, bitmap_t *src);


### PR DESCRIPTION
Returns NULL if backbuffer is not used. This allows enduser to write
directly to the backbuffer for example when reading image or video data
from SD card.